### PR TITLE
파일 사이즈 관련 예외 처리 추가

### DIFF
--- a/src/main/java/com/kk/picturequizapi/global/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/kk/picturequizapi/global/config/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.kk.picturequizapi.global.config;
 import com.kk.picturequizapi.global.exception.AbstractApiException;
 import com.kk.picturequizapi.global.exception.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -63,6 +65,19 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(DUPLICATE_LOGIN_ID.getHttpStatus())
                 .body(ErrorResponse.createErrorResponse(DUPLICATE_LOGIN_ID, request.getRequestURI()));
     }
+
+    @ExceptionHandler(FileSizeLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceededException(HttpServletRequest request) {
+        return ResponseEntity.status(FILE_SIZE_LIMIT_EXCEEDED.getHttpStatus())
+                .body(ErrorResponse.createErrorResponse(FILE_SIZE_LIMIT_EXCEEDED, request.getRequestURI()));
+    }
+    @ExceptionHandler(SizeLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleSizeLimitExceededException(HttpServletRequest request) {
+        return ResponseEntity.status(FILE_SIZE_LIMIT_EXCEEDED.getHttpStatus())
+                .body(ErrorResponse.createErrorResponse(FILE_SIZE_LIMIT_EXCEEDED, request.getRequestURI()));
+    }
+
+
 
 
 }

--- a/src/main/java/com/kk/picturequizapi/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/kk/picturequizapi/global/exception/GlobalErrorCode.java
@@ -20,7 +20,9 @@ public enum GlobalErrorCode implements ErrorCode{
     BIND_ERROR(HttpStatus.BAD_REQUEST, "G-0007","입력 값이 올바른 형식을 따르지 않았습니다."),
     CONSTRAINT_VIOLATION(HttpStatus.BAD_REQUEST, "G-0008","입력 값이 형식 검사를 통과하지 못했습니다.."),
 
-    DB_CONNECT_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "G-0009" , "현재 서비스 상태가 고르지 못해 이용에 차질이 발생합니다. 운영자 이메일을 통해 상황을 제보 부탁드립니다.")
+    DB_CONNECT_FAIL(HttpStatus.SERVICE_UNAVAILABLE, "G-0009" , "현재 서비스 상태가 고르지 못해 이용에 차질이 발생합니다. 운영자 이메일을 통해 상황을 제보 부탁드립니다."),
+
+    FILE_SIZE_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "G-0010", "업로드하신 파일의 크기가 너무 큽니다. 10MB 아래의 파일로 설정해주세요")
 
     ;
 

--- a/src/main/java/com/kk/picturequizapi/global/security/ExceptionHandlingFilter.java
+++ b/src/main/java/com/kk/picturequizapi/global/security/ExceptionHandlingFilter.java
@@ -5,6 +5,8 @@ import com.kk.picturequizapi.global.exception.AbstractApiException;
 import com.kk.picturequizapi.global.exception.ErrorResponse;
 import com.kk.picturequizapi.global.exception.LoginValidateErrorException;
 import io.jsonwebtoken.*;
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
+import org.apache.tomcat.util.http.fileupload.impl.SizeLimitExceededException;
 import org.springframework.http.HttpStatus;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -23,7 +25,8 @@ public class ExceptionHandlingFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (JwtException | AbstractApiException | CannotCreateTransactionException e) {
+        } catch (JwtException | AbstractApiException | CannotCreateTransactionException |
+                 FileSizeLimitExceededException | SizeLimitExceededException e) {
             sendErrorResponse(e, request, response);
 
         }
@@ -46,11 +49,26 @@ public class ExceptionHandlingFilter extends OncePerRequestFilter {
         if (e instanceof LoginValidateErrorException) {
             response.setStatus(BIND_ERROR.getHttpStatus().value());
             errorResponse = ErrorResponse.createErrorResponse(BIND_ERROR, request.getRequestURI());
-        }if (e instanceof CannotCreateTransactionException){
+        }
+        if (e instanceof CannotCreateTransactionException) {
             response.setStatus(DB_CONNECT_FAIL.getHttpStatus().value());
             errorResponse = ErrorResponse.createErrorResponse(DB_CONNECT_FAIL, request.getRequestURI());
-
         }
+        if (e instanceof FileSizeLimitExceededException) {
+            response.setStatus(FILE_SIZE_LIMIT_EXCEEDED.getHttpStatus().value());
+            errorResponse = ErrorResponse.createErrorResponse(FILE_SIZE_LIMIT_EXCEEDED, request.getRequestURI());
+        }
+        if (e instanceof SizeLimitExceededException) {
+            response.setStatus(FILE_SIZE_LIMIT_EXCEEDED.getHttpStatus().value());
+            errorResponse = ErrorResponse.createErrorResponse(FILE_SIZE_LIMIT_EXCEEDED, request.getRequestURI());
+        }
+
+
+
+
+
+
+
         ObjectMapper mapper = new ObjectMapper();
         String errorMsg = mapper.writeValueAsString(errorResponse);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,13 @@ spring:
       connection-timeout: 7000
   cache:
     type: redis
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
 
 quiz:
   limit : 12
-
+server:
+  tomcat:
+    max-swallow-size: 20MB


### PR DESCRIPTION
## 🎯작업 목표

유저가 파일 사이즈를 초과해서 업로드 하는 것에 대해서 예외 처리를 해준다..

파일 사이즈를 초과된 것에 대한 에러를 처리한다.

참고 자료

[[Spring의 MaxUploadSizeExceededException](https://velog.io/@park2348190/Spring%EC%9D%98-MaxUploadSizeExceededException)](https://velog.io/@park2348190/Spring%EC%9D%98-MaxUploadSizeExceededException)

[[MultipartProperties의 max-file-size, max-request-size](https://velog.io/@park2348190/MultipartProperties%EC%9D%98-max-file-size-max-request-size%EC%9D%98-%EC%B0%A8%EC%9D%B4)](https://velog.io/@park2348190/MultipartProperties%EC%9D%98-max-file-size-max-request-size%EC%9D%98-%EC%B0%A8%EC%9D%B4)

## ▶️진행 상황

**백엔드**

파일 사이즈 관련 설정 추가

```yaml
spring:	
	servlet:
    multipart:
      max-request-size: 10MB
      max-file-size: 10MB
server:
  tomcat:
    max-swallow-size: 20MB
```

multipart.max-request-size → 전체 request되는 용량 제한

multipart.max-file-size → 파일 전달하는 전체 용량

server.tomcat.max-swallow-size → tomcat이 수용하는 최대의 용량. 여기에서 설정한 용량이 넘어가면 서버 내부 처리까지 넘어오지 않고 뱉어버린다.

그래서 저 용량은 어느정도 사이즈를 잡아 줘야 서버에서 설정해주는 예외 처리 핸들링을 할 수 있따.

**프론트엔드**

```jsx
// file select

if (e.target.files[0] !== undefined) {
            if(e.target.files[0].size >10485760 ){
                const dataTranster = new DataTransfer();
                e.target.files = dataTranster.files;
                alert("업로드 할 파일은 10MB 이하로 설정해주세요");
                if (beforeImg !== undefined && beforeImg !== null) {
                    clearBox(box, beforeImg);
                }
                return;
            }
            reader.readAsDataURL(e.target.files[0]);
        }

/// upload
if (file.size > 10485760) {
            alert("업로드 할 파일은 10MB 이하로 설정해주세요");
            return;
        }
```

파일의 사이즈가 초과하면 예외를 출력해주도록 설정했다.

### ⚠️오류 발생